### PR TITLE
Make GitHub detect *.f[01][0-9] as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.[fF][01][0-9] linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.f01` etc files as Forth.

Thanks!
